### PR TITLE
Fix `filter`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=http://beta-internal:4873
+@gitterhq:registry=https://registry.npmjs.org/

--- a/index.js
+++ b/index.js
@@ -174,7 +174,11 @@ BackboneFilteredCollection.prototype = _.extend(
     return this.models.map(function(model){
       return model.toJSON();
     });
-  }
+  },
+
+  filter: function (fn){
+    return this._models.filter(fn);
+  },
 
 });
 

--- a/index.js
+++ b/index.js
@@ -55,9 +55,8 @@ BackboneFilteredCollection.prototype = _.extend(
 
     var oldModels = (this._models || []);
     this._models = [];
-    for (var i = 0; i < this.collection.length; i++) {
-      var model = this.collection.models[i];
-      var index = (i <= 0) ? 0 : (i -1);
+    for (var index = 0; index < this.collection.length; index++) {
+      var model = this.collection.models[index];
       if (this._filter(model, index)) {
         this._models.push(model);
         if((oldModels.indexOf(model) === -1)) {
@@ -85,6 +84,7 @@ BackboneFilteredCollection.prototype = _.extend(
   _onCollectionEvent: function(type) {
     var args = Array.prototype.slice.apply(arguments);
     var model = args[1];
+    var index = this._models.indexOf(model);
 
     //No filter means we just proxy everything
     if (!this._filter) {
@@ -93,14 +93,14 @@ BackboneFilteredCollection.prototype = _.extend(
 
     //only trigger if we are adding a model and it passes the filter
     if (type === 'add') {
-      if (this._filter && this._filter(model)) {
+      if (this._filter && this._filter(model, index)) {
         this._models.push(model);
         BackboneProxyCollection.prototype._onCollectionEvent.apply(this, arguments);
       }
     }
     //
     else if (type === 'remove') {
-      if (this._filter && this._filter(model)) {
+      if (this._filter && this._filter(model, index)) {
         this._models.splice(this._models.indexOf(model), 1);
         BackboneProxyCollection.prototype._onCollectionEvent.apply(this, arguments);
       }
@@ -112,13 +112,12 @@ BackboneFilteredCollection.prototype = _.extend(
     }
     //
     else if(type === 'change') {
-      var index = this._models.indexOf(model);
-      if (this._filter && this._filter(model)) {
+      if (this._filter && this._filter(model, index)) {
         if(index === -1) {
           this._models.push(model);
           this._models = this._models.sort(this.comparator);
-          BackboneProxyCollection.prototype._onCollectionEvent.apply(this, arguments);
         }
+        BackboneProxyCollection.prototype._onCollectionEvent.apply(this, arguments);
       }
       else {
         if(index !== -1){
@@ -127,6 +126,7 @@ BackboneFilteredCollection.prototype = _.extend(
           BackboneProxyCollection.prototype._onCollectionEvent.apply(this, arguments);
         }
       }
+
     }
 
     //proxy everything else

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test:int && npm run test:unit && npm run test:post:cov",
+    "test": "npm run test:int && npm run test:unit",
     "test:unit": "istanbul cover ./node_modules/mocha/bin/_mocha ./test/specs/**/*.js",
     "test:unit:dev": "mocha -w  ./test/specs/**/*.js",
     "test:bench": "node ./test/benchmarks/index.js",

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -13,12 +13,15 @@ describe('BackboneFilteredCollection', function() {
   var filter = function(model) {
     return !(model.get('id') % 2);
   };
+  var filterByIndex = function(model, index) {
+    return index < 5;
+  };
 
   var compare = function() { return 0; };
 
   beforeEach(function() {
     _collection = new Backbone.Collection(_.range(100).map(function(i) {
-      return { id: i };
+      return { id: i, foo: 0 };
     }));
 
     collection = new BackboneFilteredCollection({ collection: _collection, comparator: compare });
@@ -28,6 +31,21 @@ describe('BackboneFilteredCollection', function() {
     assert.equal(_collection.length, collection.length);
     assert.deepEqual(_collection.models, collection.models);
   });
+
+  it('should maintain same models after arbitrary attribute change', function(done) {
+    collection.setFilter(filterByIndex);
+    assert.equal(5, collection.length);
+    assert.equal(5, collection.models.length);
+    collection.on('change', function() {
+      setTimeout(function() {
+        assert.equal(5, collection.length);
+        assert.equal(5, collection.models.length);
+        done();
+      }, 0);
+    });
+    collection.at(1).set({ foo: 1 });
+  });
+
 
   it('should filter the collection when setFilter is called', function() {
     collection.setFilter(filter);

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -303,4 +303,12 @@ describe('BackboneFilteredCollection', function() {
     assert.equal(50, count);
   });
 
+  it('should use the correct number of models when filter is called', function(){
+    collection.setFilter(filter);
+    var l = collection.length;
+    collection.filter(function(model, index){
+      assert(index < l);
+    });
+  });
+
 });


### PR DESCRIPTION
Depends on #4 

In master, if you call `filter` it will filter `collection.models` which obviously iterates through the entire collection not the filtered models. This PR fixes that. 
